### PR TITLE
Interfaces for conditional include

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -69,7 +69,7 @@ func Hash(v interface{}, opts *HashOptions) (uint64, error) {
 		w:   opts.Hasher,
 		tag: opts.TagName,
 	}
-	if err := w.visit(reflect.ValueOf(v), 0); err != nil {
+	if err := w.visit(reflect.ValueOf(v), nil); err != nil {
 		return 0, err
 	}
 
@@ -81,7 +81,16 @@ type walker struct {
 	tag string
 }
 
-func (w *walker) visit(v reflect.Value, f visitFlag) error {
+type visitOpts struct {
+	// Flags are a bitmask of flags to affect behavior of this visit
+	Flags visitFlag
+
+	// Information about the struct containing this field
+	Struct      interface{}
+	StructField string
+}
+
+func (w *walker) visit(v reflect.Value, opts *visitOpts) error {
 	// Loop since these can be wrapped in multiple layers of pointers
 	// and interfaces.
 	for {
@@ -133,17 +142,34 @@ func (w *walker) visit(v reflect.Value, f visitFlag) error {
 	case reflect.Array:
 		l := v.Len()
 		for i := 0; i < l; i++ {
-			if err := w.visit(v.Index(i), 0); err != nil {
+			if err := w.visit(v.Index(i), nil); err != nil {
 				return err
 			}
 		}
 
 	case reflect.Map:
+		var includeMap IncludableMap
+		if opts != nil && opts.Struct != nil {
+			if v, ok := opts.Struct.(IncludableMap); ok {
+				includeMap = v
+			}
+		}
+
 		// Build the hash for the map. We do this by XOR-ing all the key
 		// and value hashes. This makes it deterministic despite ordering.
 		var h uint64
 		for _, k := range v.MapKeys() {
 			v := v.MapIndex(k)
+			if includeMap != nil {
+				incl, err := includeMap.HashIncludeMap(
+					opts.StructField, k.Interface(), v.Interface())
+				if err != nil {
+					return err
+				}
+				if !incl {
+					continue
+				}
+			}
 
 			kh, err := Hash(k.Interface(), nil)
 			if err != nil {
@@ -160,6 +186,7 @@ func (w *walker) visit(v reflect.Value, f visitFlag) error {
 		return binary.Write(w.w, binary.LittleEndian, h)
 
 	case reflect.Struct:
+		parent := v.Interface()
 		t := v.Type()
 		l := v.NumField()
 		for i := 0; i < l; i++ {
@@ -177,7 +204,12 @@ func (w *walker) visit(v reflect.Value, f visitFlag) error {
 					f |= visitFlagSet
 				}
 
-				if err := w.visit(v, f); err != nil {
+				err := w.visit(v, &visitOpts{
+					Flags:       f,
+					Struct:      parent,
+					StructField: fieldType.Name,
+				})
+				if err != nil {
 					return err
 				}
 			}
@@ -188,7 +220,10 @@ func (w *walker) visit(v reflect.Value, f visitFlag) error {
 		// visit all the elements. If it is a set, then we do a deterministic
 		// hash code.
 		var h uint64
-		set := (f & visitFlagSet) != 0
+		var set bool
+		if opts != nil {
+			set = (opts.Flags & visitFlagSet) != 0
+		}
 		l := v.Len()
 		for i := 0; i < l; i++ {
 			var err error
@@ -197,7 +232,7 @@ func (w *walker) visit(v reflect.Value, f visitFlag) error {
 				hc, err = Hash(v.Index(i).Interface(), nil)
 				h = h ^ hc
 			} else {
-				err = w.visit(v.Index(i), 0)
+				err = w.visit(v.Index(i), nil)
 			}
 			if err != nil {
 				return err

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -183,3 +183,65 @@ func TestHash_equalSet(t *testing.T) {
 		}
 	}
 }
+
+func TestHash_includableMap(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"foo": "bar"}},
+			true,
+		},
+
+		{
+			testIncludableMap{Map: map[string]string{"foo": "bar", "ignore": "true"}},
+			testIncludableMap{Map: map[string]string{"bar": "baz"}},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
+type testIncludableMap struct {
+	Map map[string]string
+}
+
+func (t testIncludableMap) HashIncludeMap(field string, k, v interface{}) (bool, error) {
+	if field != "Map" {
+		return true, nil
+	}
+
+	if s, ok := k.(string); ok && s == "ignore" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -184,6 +184,52 @@ func TestHash_equalSet(t *testing.T) {
 	}
 }
 
+func TestHash_includable(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testIncludable{Value: "foo"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "foo"},
+			true,
+		},
+
+		{
+			testIncludable{Value: "foo", Ignore: "bar"},
+			testIncludable{Value: "bar"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
 func TestHash_includableMap(t *testing.T) {
 	cases := []struct {
 		One, Two interface{}
@@ -228,6 +274,15 @@ func TestHash_includableMap(t *testing.T) {
 			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
 		}
 	}
+}
+
+type testIncludable struct {
+	Value  string
+	Ignore string
+}
+
+func (t testIncludable) HashInclude(field string, v interface{}) (bool, error) {
+	return field != "Ignore", nil
 }
 
 type testIncludableMap struct {

--- a/include.go
+++ b/include.go
@@ -1,0 +1,8 @@
+package hashstructure
+
+// IncludableMap is an interface that can optionally be implemented by
+// a struct. It will be called when a map-type field is found to ask the
+// struct if the map item should be included in the hash.
+type IncludableMap interface {
+	HashIncludeMap(field string, k, v interface{}) (bool, error)
+}

--- a/include.go
+++ b/include.go
@@ -1,5 +1,12 @@
 package hashstructure
 
+// Includable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// it should be included in the hash.
+type Includable interface {
+	HashInclude(field string, v interface{}) (bool, error)
+}
+
 // IncludableMap is an interface that can optionally be implemented by
 // a struct. It will be called when a map-type field is found to ask the
 // struct if the map item should be included in the hash.


### PR DESCRIPTION
This adds two new optional interfaces to control conditional inclusion in the final hash code:

  * `Includable` - Run for every field in a struct to check if it should be included.

  * `IncludableMap` - Run for map-type fields in a struct to allow you to introspect on the key/value to determine if it should be included.