### PR TITLE
Support hash:"-" and improve readme slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hashstructure
+# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
 
 hashstructure is a Go library for creating a unique hash value
 for arbitrary values in Go.
@@ -34,28 +34,29 @@ For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/has
 
 A quick code example is shown below:
 
+```go
+type ComplexStruct struct {
+    Name     string
+    Age      uint
+    Metadata map[string]interface{}
+}
 
-	type ComplexStruct struct {
-		Name     string
-		Age      uint
-		Metadata map[string]interface{}
-	}
+v := ComplexStruct{
+    Name: "mitchellh",
+    Age:  64,
+    Metadata: map[string]interface{}{
+        "car":      true,
+        "location": "California",
+        "siblings": []string{"Bob", "John"},
+    },
+}
 
-	v := ComplexStruct{
-		Name: "mitchellh",
-		Age:  64,
-		Metadata: map[string]interface{}{
-			"car":      true,
-			"location": "California",
-			"siblings": []string{"Bob", "John"},
-		},
-	}
+hash, err := hashstructure.Hash(v, nil)
+if err != nil {
+    panic(err)
+}
 
-	hash, err := hashstructure.Hash(v, nil)
-	if err != nil {
-		panic(err)
-	}
-
-	fmt.Printf("%d", hash)
-	// Output:
-	// 2307517237273902113
+fmt.Printf("%d", hash)
+// Output:
+// 2307517237273902113
+```

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -41,7 +41,7 @@ type HashOptions struct {
 //
 // The available tag values are:
 //
-//   * "ignore" - The field will be ignored and not affect the hash code.
+//   * "ignore" or "-" - The field will be ignored and not affect the hash code.
 //
 //   * "set" - The field will be treated as a set, where ordering doesn't
 //             affect the hash code. This only works for slices.
@@ -212,7 +212,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				}
 
 				tag := fieldType.Tag.Get(w.tag)
-				if tag == "ignore" {
+				if tag == "ignore" || tag == "-" {
 					// Ignore this field
 					continue
 				}

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -150,9 +150,14 @@ func TestHash_equal(t *testing.T) {
 }
 
 func TestHash_equalIgnore(t *testing.T) {
-	type Test struct {
+	type Test1 struct {
 		Name string
 		UUID string `hash:"ignore"`
+	}
+
+	type Test2 struct {
+		Name string
+		UUID string `hash:"-"`
 	}
 
 	cases := []struct {
@@ -160,14 +165,26 @@ func TestHash_equalIgnore(t *testing.T) {
 		Match    bool
 	}{
 		{
-			Test{Name: "foo", UUID: "foo"},
-			Test{Name: "foo", UUID: "bar"},
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "bar"},
 			true,
 		},
 
 		{
-			Test{Name: "foo", UUID: "foo"},
-			Test{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "foo"},
+			Test1{Name: "foo", UUID: "foo"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "bar"},
+			true,
+		},
+
+		{
+			Test2{Name: "foo", UUID: "foo"},
+			Test2{Name: "foo", UUID: "foo"},
 			true,
 		},
 	}


### PR DESCRIPTION
Hi!

This PR adds support for `hash:"-"`, alternative syntax for `hash:"ignore"`, and improves README slightly.

The motivation is that `"-"` is more compact and commonly used (e.g. in `encoding/json` and various ORMs).