### PR TITLE
add hash:"string" tags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ sending data across the network, caching values locally (de-dup), and so on.
 
   * Optionally specify a custom hash function to optimize for speed, collision
     avoidance for your data set, etc.
+  
+  * Optionally hash the output of `.String()` on structs that implement fmt.Stringer,
+    allowing effective hashing of time.Time
 
 ## Installation
 

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -3,6 +3,7 @@ package hashstructure
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestHash_identity(t *testing.T) {
@@ -195,6 +196,17 @@ func TestHash_equalIgnore(t *testing.T) {
 		UUID string `hash:"-"`
 	}
 
+	type TestTime struct {
+		Name string
+		Time time.Time `hash:"string"`
+	}
+
+	type TestTime2 struct {
+		Name string
+		Time time.Time
+	}
+
+	now := time.Now()
 	cases := []struct {
 		One, Two interface{}
 		Match    bool
@@ -220,6 +232,21 @@ func TestHash_equalIgnore(t *testing.T) {
 		{
 			Test2{Name: "foo", UUID: "foo"},
 			Test2{Name: "foo", UUID: "foo"},
+			true,
+		},
+		{
+			TestTime{Name: "foo", Time: now},
+			TestTime{Name: "foo", Time: time.Time{}},
+			false,
+		},
+		{
+			TestTime{Name: "foo", Time: now},
+			TestTime{Name: "foo", Time: now},
+			true,
+		},
+		{
+			TestTime2{Name: "foo", Time: now},
+			TestTime2{Name: "foo", Time: time.Time{}},
 			true,
 		},
 	}


### PR DESCRIPTION
This PR adds support for hashing things that implement `fmt.Stringer` via an additional struct tag to maintain backwards compatibility. This is especially useful when you have structs that contain `time.Time` in them, as there are no exported fields in it. 


edit: this looks awfully similar in purpose to https://github.com/hashicorp/vault/pull/2689