### PR TITLE
Adds option IgnoreZeroValue to ignore zero value fields

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -249,9 +249,11 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 					continue
 				}
 
-				zeroVal := reflect.Zero(reflect.TypeOf(innerV.Interface())).Interface()
-				if w.ignorezerovalue && reflect.DeepEqual(innerV.Interface(), zeroVal) {
-					continue
+				if w.ignorezerovalue {
+					zeroVal := reflect.Zero(reflect.TypeOf(innerV.Interface())).Interface()
+					if innerV.Interface() == zeroVal {
+						continue
+					}
 				}
 
 				// if string is set, use the string value

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -493,6 +493,48 @@ func TestHash_includable(t *testing.T) {
 	}
 }
 
+func TestHash_ignoreZeroValue(t *testing.T) {
+	cases := []struct {
+		IgnoreZeroValue bool
+	}{
+		{
+			IgnoreZeroValue: true,
+		},
+		{
+			IgnoreZeroValue: false,
+		},
+	}
+	structA := struct {
+		Foo string
+		Bar string
+	}{
+		Foo: "foo",
+		Bar: "bar",
+	}
+	structB := struct {
+		Foo string
+		Bar string
+		Baz string
+	}{
+		Foo: "foo",
+		Bar: "bar",
+	}
+
+	for _, tc := range cases {
+		hashA, err := Hash(structA, &HashOptions{IgnoreZeroValue: tc.IgnoreZeroValue})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", structA, err)
+		}
+		hashB, err := Hash(structB, &HashOptions{IgnoreZeroValue: tc.IgnoreZeroValue})
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", structB, err)
+		}
+		if (hashA == hashB) != tc.IgnoreZeroValue {
+			t.Fatalf("bad, expected: %#v\n\n%#d\n\n%#d", tc.IgnoreZeroValue, hashA, hashB)
+		}
+	}
+}
+
 func TestHash_includableMap(t *testing.T) {
 	cases := []struct {
 		One, Two interface{}

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -530,7 +530,7 @@ func TestHash_ignoreZeroValue(t *testing.T) {
 			t.Fatalf("Failed to hash %#v: %s", structB, err)
 		}
 		if (hashA == hashB) != tc.IgnoreZeroValue {
-			t.Fatalf("bad, expected: %#v\n\n%#d\n\n%#d", tc.IgnoreZeroValue, hashA, hashB)
+			t.Fatalf("bad, expected: %#v\n\n%d\n\n%d", tc.IgnoreZeroValue, hashA, hashB)
 		}
 	}
 }


### PR DESCRIPTION
This is to aid in cases, where a struct, that hashes were generated from, may be extended by a field.

In our use-case the hash value should not change, unless that field was actually given a value.

Example:
```golang
package main

import (
	"fmt"
	"github.com/mitchellh/hashstructure"
)

func main() {
	structA := struct {
		Foo string
	}{
		Foo: "Foo",
	}
	structB := struct {
		Foo string
		Bar string
	}{
		Foo: "Foo",
	}
	hashA, _ := hashstructure.Hash(structA, &hashstructure.HashOptions{})
	hashB, _ := hashstructure.Hash(structB, &hashstructure.HashOptions{})
	fmt.Printf("Default\n%#v\n%v, %v\n\n", (hashA == hashB), hashA, hashB)

	hashA, _ = hashstructure.Hash(structA, &hashstructure.HashOptions{IgnoreZeroValue: true})
	hashB, _ = hashstructure.Hash(structB, &hashstructure.HashOptions{IgnoreZeroValue: true})
	fmt.Printf("IgnoreZeroValue\n%#v\n%v, %v\n\n", (hashA == hashB), hashA, hashB)
}
```

Output:
```
$  go run cmd/main.go
Default
false
16099080255207288176, 14930193348031619563

IgnoreZeroValue
true
16099080255207288176, 16099080255207288176
```

Thank you for creating this great library and looking forward to hearing your thoughts and feedback on this!