### PR TITLE
Make set hashing robust to bitwise XOR cancellations

### DIFF
--- a/hashstructure_examples_test.go
+++ b/hashstructure_examples_test.go
@@ -28,5 +28,5 @@ func ExampleHash() {
 
 	fmt.Printf("%d", hash)
 	// Output:
-	// 6691276962590150517
+	// 1839806922502695369
 }

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -97,7 +97,7 @@ func TestHash_equal(t *testing.T) {
 		{
 			struct{ Lname, Fname string }{"foo", "bar"},
 			struct{ Fname, Lname string }{"bar", "foo"},
-			true,
+			false,
 		},
 
 		{


### PR DESCRIPTION
The way sets (maps, structs, slices with the "set" tag) are hashed
relies on an XOR to mix the hashes of their elements. This allows
multiple independent items to interfere with each other through XOR
operations. For example, consider a "set" slice with the following two
structs:

```
[
  {Key: "a", Value: "v1"},
  {Key: "a", Value: "v2"}
]
```

Changing both keys from "a" to "b" will not change the hash value of the
overall object, since in either case the two keys will cancel out under
XOR arithmetic.

This change fixes the problem by adding a step after every set of
unordered hash operations that "hardens" the result by applying another
hash. It will prevent components of one unordered hashing operation (for
example, `Key: "a"` above) from interacting with the same data
encountered later in a different context.

Note that this changes hashes produced by the package for given inputs.

Closes: #18