### PR TITLE
Fix time.Time hashes

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"reflect"
+	"time"
 )
 
 // ErrNotStringer is returned when there's an error with hash:"string"
@@ -104,6 +105,8 @@ type visitOpts struct {
 	StructField string
 }
 
+var timeType = reflect.TypeOf(time.Time{})
+
 func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 	t := reflect.TypeOf(0)
 
@@ -156,6 +159,18 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		// A direct hash calculation
 		w.h.Reset()
 		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
+		return w.h.Sum64(), err
+	}
+
+	switch v.Type() {
+	case timeType:
+		w.h.Reset()
+		b, err := v.Interface().(time.Time).MarshalBinary()
+		if err != nil {
+			return 0, err
+		}
+
+		err = binary.Write(w.h, binary.LittleEndian, b)
 		return w.h.Sum64(), err
 	}
 

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -66,6 +66,8 @@ func TestHash_equal(t *testing.T) {
 	type testFoo struct{ Name string }
 	type testBar struct{ Name string }
 
+	now := time.Now()
+
 	cases := []struct {
 		One, Two interface{}
 		Match    bool
@@ -153,6 +155,12 @@ func TestHash_equal(t *testing.T) {
 			}{
 				Foo: "bar",
 			},
+			true,
+		},
+		{
+			now, // contains monotonic clock
+			time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
+				now.Minute(), now.Second(), now.Nanosecond(), now.Location()), // does not contain monotonic clock
 			true,
 		},
 	}
@@ -247,6 +255,13 @@ func TestHash_equalIgnore(t *testing.T) {
 		{
 			TestTime2{Name: "foo", Time: now},
 			TestTime2{Name: "foo", Time: time.Time{}},
+			false,
+		},
+		{
+			TestTime2{Name: "foo", Time: now},
+			TestTime2{Name: "foo", Time: time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
+				now.Minute(), now.Second(), now.Nanosecond(), now.Location()),
+			},
 			true,
 		},
 	}


### PR DESCRIPTION
Fixes #16.

`time.Time` is a struct without any exported values. The current implementation treats it as a struct. Since it does not have any exported values, it's hashed as a struct with the name `Time` and nothing else. This means that any `time.Time` that is hashed will produce the same result, regardless of what its internal values are.

I added a check to check if the type being hashed is a `time.Time`, then use it to hash the binary version of the time (produced using the `MarshalBinary()` method). The `MarshalBinary()` method was used because it drops the monotonic clock component of the time before returning the binary representation, otherwise, 2 identical times with different monotonic clock components will generate different hashes.