### PR TITLE
Options to always attempts `fmt.Stringer` and to always assume `hash:"set"`

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -272,7 +272,6 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				if w.stringer {
 					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
 						innerV = reflect.ValueOf(impl.String())
-						continue
 					}
 				}
 

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -31,6 +31,17 @@ type HashOptions struct {
 	// ZeroNil is flag determining if nil pointer should be treated equal
 	// to a zero value of pointed type. By default this is false.
 	ZeroNil bool
+
+	// SlicesAsSets assumes that a `set` tag is always present for slices.
+	// Default is false (in which case the tag is used instead)
+	SlicesAsSets bool
+
+	// UseStringer will attempt to use fmt.Stringer aways. If the struct
+	// doesn't implement fmt.Stringer, it'll fall back to trying usual tricks.
+	// If this is true, and the "string" tag is also set, the tag takes
+	// precedense (meaning that if the type doesn't implement fmt.Stringer, we
+	// panic)
+	UseStringer bool
 }
 
 // Hash returns the hash value of an arbitrary value.
@@ -82,9 +93,11 @@ func Hash(v interface{}, opts *HashOptions) (uint64, error) {
 
 	// Create our walker and walk the structure
 	w := &walker{
-		h:       opts.Hasher,
-		tag:     opts.TagName,
-		zeronil: opts.ZeroNil,
+		h:        opts.Hasher,
+		tag:      opts.TagName,
+		zeronil:  opts.ZeroNil,
+		sets:     opts.SlicesAsSets,
+		stringer: opts.UseStringer,
 	}
 	return w.visit(reflect.ValueOf(v), nil)
 }
@@ -93,6 +106,7 @@ type walker struct {
 	h       hash.Hash64
 	tag     string
 	zeronil bool
+	sets    bool
 }
 
 type visitOpts struct {
@@ -253,6 +267,14 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 					}
 				}
 
+				// if Use Stringer option is set, attempt that
+				if opts.stringer {
+					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
+						innerV = reflect.ValueOf(impl.String())
+						continue
+					}
+				}
+
 				// Check if we implement includable and check it
 				if include != nil {
 					incl, err := include.HashInclude(fieldType.Name, innerV)
@@ -306,7 +328,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				return 0, err
 			}
 
-			if set {
+			if set || opts.sets {
 				h = hashUpdateUnordered(h, current)
 			} else {
 				h = hashUpdateOrdered(w.h, h, current)

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -103,10 +103,11 @@ func Hash(v interface{}, opts *HashOptions) (uint64, error) {
 }
 
 type walker struct {
-	h       hash.Hash64
-	tag     string
-	zeronil bool
-	sets    bool
+	h        hash.Hash64
+	tag      string
+	zeronil  bool
+	sets     bool
+	stringer bool
 }
 
 type visitOpts struct {
@@ -268,7 +269,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				}
 
 				// if Use Stringer option is set, attempt that
-				if opts.stringer {
+				if w.stringer {
 					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
 						innerV = reflect.ValueOf(impl.String())
 						continue
@@ -328,7 +329,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				return 0, err
 			}
 
-			if set || opts.sets {
+			if set || w.sets {
 				h = hashUpdateUnordered(h, current)
 			} else {
 				h = hashUpdateOrdered(w.h, h, current)


### PR DESCRIPTION
For large structs and legacy code, it's nice to be able to create a checksum without first having to go through all the code and set tags on many fields.

This change introduces options to always assume that a slice is a set, and to always use the `fmt.Stringer` interface for a struct, if it is present.

The `SlicesAsSets` option overrides the tag (since it will no longer have any effect).
The `UseStringer` option is overridden by the tag, in the sense that if the tag is set, it is an error if the type does not implement `fmt.Stringer`. Using the option alone, we fall back to the default hashing, with the caveat that this means that structs with unexported fields will not be hashed if they don't implement `fmt.Stringer`.

This change is included in my own fork at `github.com/adamhassel/hashstructure` for anyone interested.