### PR TITLE
Fix multiple unequal structs xor'ing to a collision

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -288,6 +288,8 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 			}
 		}
 
+		h = hashUpdateOrdered(w.h, h, h)
+
 		return h, nil
 
 	case reflect.Slice:

--- a/hashstructure_examples_test.go
+++ b/hashstructure_examples_test.go
@@ -28,5 +28,5 @@ func ExampleHash() {
 
 	fmt.Printf("%d", hash)
 	// Output:
-	// 6691276962590150517
+	// 15164222915390066889
 }

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -66,6 +66,11 @@ func TestHash_equal(t *testing.T) {
 	type testFoo struct{ Name string }
 	type testBar struct{ Name string }
 
+	type testItem struct {
+		Name string
+		Prio int
+	}
+
 	cases := []struct {
 		One, Two interface{}
 		Match    bool
@@ -98,6 +103,11 @@ func TestHash_equal(t *testing.T) {
 			struct{ Lname, Fname string }{"foo", "bar"},
 			struct{ Fname, Lname string }{"bar", "foo"},
 			true,
+		},
+		{
+			[]testItem{{"foo", 1}, {"bar", 2}},
+			[]testItem{{"foo", 2}, {"bar", 1}},
+			false,
 		},
 
 		{
@@ -562,4 +572,32 @@ func (t testIncludableMap) HashIncludeMap(field string, k, v interface{}) (bool,
 	}
 
 	return true, nil
+}
+
+func TestHash_set(t *testing.T) {
+	type Item struct {
+		Name     string
+		Priority int
+	}
+
+	type BitwiseXORTest struct {
+		Name  string
+		Items []Item `hash:"set"`
+	}
+
+	testCase1 := BitwiseXORTest{
+		"testCase",
+		[]Item{{"FirstItem", 1}, {"SecondItem", 2}},
+	}
+	testCase2 := BitwiseXORTest{
+		"testCase",
+		[]Item{{"SecondItem", 1}, {"FirstItem", 2}},
+	}
+
+	hash1, _ := Hash(testCase1, nil)
+	hash2, _ := Hash(testCase2, nil)
+
+	if hash1 == hash2 {
+		t.Fatal("hashes shouldn't match")
+	}
 }


### PR DESCRIPTION
Attempts to fix https://github.com/mitchellh/hashstructure/issues/18 by clamping the hash value of a struct rather than having it to be composed only of the hash value of it's fields.