### PR TITLE
add SliceAsSetsable interface

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -281,6 +281,10 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		if impl, ok := parent.(Includable); ok {
 			include = impl
 		}
+		var sliceAsSets SliceAsSetsable
+		if impl, ok := parent.(SliceAsSetsable); ok {
+			sliceAsSets = impl
+		}
 
 		if impl, ok := parent.(Hashable); ok {
 			return impl.Hash()
@@ -293,6 +297,9 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 			parentptr := vptr.Interface()
 			if impl, ok := parentptr.(Includable); ok {
 				include = impl
+			}
+			if impl, ok := parentptr.(SliceAsSetsable); ok {
+				sliceAsSets = impl
 			}
 
 			if impl, ok := parentptr.(Hashable); ok {
@@ -350,6 +357,17 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 					}
 					if !incl {
 						continue
+					}
+				}
+
+				// Check if we implement SliceAsSetsable
+				if sliceAsSets != nil {
+					sas, err := sliceAsSets.SliceAsSets(fieldType.Name, innerV)
+					if err != nil {
+						return 0, err
+					}
+					if sas {
+						f |= visitFlagSet
 					}
 				}
 

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -674,6 +674,55 @@ func TestHash_hashable(t *testing.T) {
 	}
 }
 
+func TestHash_sliceAsSetsable(t *testing.T) {
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+	}{
+		{
+			testSliceAsSetsable{Kind: "map", Slice: []string{"1", "2"}, SliceSet: []string{"a", "b"}},
+			testSliceAsSetsable{Kind: "map", Slice: []string{"2", "1"}, SliceSet: []string{"a", "b"}},
+			true,
+		},
+		{
+			testSliceAsSetsable{Kind: "map", Slice: []string{"1", "2"}, SliceSet: []string{"a", "b"}},
+			testSliceAsSetsable{Kind: "map", Slice: []string{"2", "1"}, SliceSet: []string{"b", "a"}},
+			true,
+		},
+		{
+			testSliceAsSetsable{Kind: "seq", Slice: []string{"1", "2"}, SliceSet: []string{"a", "b"}},
+			testSliceAsSetsable{Kind: "seq", Slice: []string{"2", "1"}, SliceSet: []string{"a", "b"}},
+			false,
+		},
+		{
+			testSliceAsSetsable{Kind: "seq", Slice: []string{"1", "2"}, SliceSet: []string{"a", "b"}},
+			testSliceAsSetsable{Kind: "seq", Slice: []string{"1", "2"}, SliceSet: []string{"b", "a"}},
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		one, err := Hash(tc.One, testFormat, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+		}
+		two, err := Hash(tc.Two, testFormat, nil)
+		if err != nil {
+			t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+		}
+
+		// Zero is always wrong
+		if one == 0 {
+			t.Fatalf("zero hash: %#v", tc.One)
+		}
+
+		// Compare
+		if (one == two) != tc.Match {
+			t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+		}
+	}
+}
+
 type testIncludable struct {
 	Value  string
 	Ignore string
@@ -726,4 +775,20 @@ func (t *testHashablePointer) Hash() (uint64, error) {
 	}
 
 	return 100, nil
+}
+
+type testSliceAsSetsable struct {
+	Kind     string
+	Slice    []string
+	SliceSet []string
+}
+
+func (t testSliceAsSetsable) SliceAsSets(field string, v interface{}) (bool, error) {
+	switch t.Kind {
+	case "map":
+		return true, nil
+	case "seq":
+		return field == "SliceSet", nil
+	}
+	return false, nil
 }

--- a/include.go
+++ b/include.go
@@ -20,3 +20,10 @@ type IncludableMap interface {
 type Hashable interface {
 	Hash() (uint64, error)
 }
+
+// SliceAsSetsable is an interface that can optionally be implemented by
+// a struct. It will be called for each field in the struct to check whether
+// the filed should be treated as set.
+type SliceAsSetsable interface {
+	SliceAsSets(field string, v interface{}) (bool, error)
+}


### PR DESCRIPTION
I want to use the hashstructure to compute compatible hash of json schema, and first I use the yaml lib to unmarshal json schema because of its simplicity, the struct is something like this:

type Node struct {
    Kind int
    Content []*Nodes
}

The Kind == 2 stands for a Sequence and Kind == 4 stands for a Map, when compute hash, I want to set sliceAsSets to true for Map and false to Sequence, but tag solution can not do this, so I want to add a interface to solve it.