### PR TITLE
Use built-in IsZero function

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -323,8 +323,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				}
 
 				if w.ignorezerovalue {
-					zeroVal := reflect.Zero(reflect.TypeOf(innerV.Interface())).Interface()
-					if innerV.Interface() == zeroVal {
+					if innerV.IsZero() {
 						continue
 					}
 				}

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -525,6 +525,7 @@ func TestHash_ignoreZeroValue(t *testing.T) {
 	structA := struct {
 		Foo string
 		Bar string
+		Map map[string]int
 	}{
 		Foo: "foo",
 		Bar: "bar",
@@ -533,6 +534,7 @@ func TestHash_ignoreZeroValue(t *testing.T) {
 		Foo string
 		Bar string
 		Baz string
+		Map map[string]int
 	}{
 		Foo: "foo",
 		Bar: "bar",


### PR DESCRIPTION
We can cause a crash by setting `IgnoreZeroValue` and hashing a struct containing a zero-value map.

Use the built in `IsZero` function to avoid this.

```
	panic: runtime error: comparing uncomparable type map[string]int

goroutine 36 [running]:
testing.tRunner.func1.2(0x1134f40, 0xc0001b2130)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc0001b4180)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1146 +0x4b6
panic(0x1134f40, 0xc0001b2130)
	/usr/local/Cellar/go/1.16.3/libexec/src/runtime/panic.go:965 +0x1b9
github.com/mitchellh/hashstructure/v2.(*walker).visit(0xc000123ed0, 0x1138320, 0x0, 0x19, 0x0, 0x1158e00, 0xc0001b0c18, 0x10cfb64)
	/Users/mwhooker/go/src/github.com/mitchellh/hashstructure/hashstructure.go:328 +0x1145
github.com/mitchellh/hashstructure/v2.Hash(0x1138320, 0x0, 0x2, 0xc000046f48, 0xc020a8aff0, 0x20a8aff0010cf930, 0x60b02302)
	/Users/mwhooker/go/src/github.com/mitchellh/hashstructure/hashstructure.go:128 +0x1cb
github.com/mitchellh/hashstructure/v2.TestHash_zeroMap(0xc0001b4180)
	/Users/mwhooker/go/src/github.com/mitchellh/hashstructure/hashstructure_test.go:564 +0x67
testing.tRunner(0xc0001b4180, 0x1162df0)
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.16.3/libexec/src/testing/testing.go:1238 +0x2b3
exit status 2
FAIL	github.com/mitchellh/hashstructure/v2	0.143s
```

Closes #31