### PR TITLE
Fix timetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ sending data across the network, caching values locally (de-dup), and so on.
 Standard `go get`:
 
 ```
-$ go get github.com/mitchellh/hashstructure
+$ go get github.com/adamhassel/hashstructure
 ```
 
 ## Usage & Example
 
-For usage and examples see the [Godoc](http://godoc.org/github.com/mitchellh/hashstructure).
+For usage and examples see the [Godoc](http://godoc.org/github.com/adamhassel/hashstructure).
 
 A quick code example is shown below:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# hashstructure [![GoDoc](https://godoc.org/github.com/mitchellh/hashstructure?status.svg)](https://godoc.org/github.com/mitchellh/hashstructure)
+# hashstructure [![GoDoc](https://godoc.org/github.com/adamhassel/hashstructure?status.svg)](https://godoc.org/github.com/adamhassel/hashstructure)
 
 hashstructure is a Go library for creating a unique hash value
 for arbitrary values in Go.

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/mitchellh/hashstructure
+module github.com/adamhassel/hashstructure

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -1,6 +1,7 @@
 package hashstructure
 
 import (
+	"encoding"
 	"encoding/binary"
 	"fmt"
 	"hash"
@@ -37,6 +38,11 @@ type HashOptions struct {
 	// precedence (meaning that if the type doesn't implement fmt.Stringer, we
 	// panic)
 	UseStringer bool
+
+	// UseBinary will use the encoding.BinaryMarshaler for any type that implements
+	// that interface. Common types are time.Time and url.URL. Note that if you explicitly set
+	// the 'string' tag on a field, that will take precedence over this option.
+	UseBinary bool
 }
 
 // Format specifies the hashing process used. Different formats typically
@@ -124,6 +130,7 @@ func Hash(v interface{}, format Format, opts *HashOptions) (uint64, error) {
 		ignorezerovalue: opts.IgnoreZeroValue,
 		sets:            opts.SlicesAsSets,
 		stringer:        opts.UseStringer,
+		binary:          opts.UseBinary,
 	}
 	return w.visit(reflect.ValueOf(v), nil)
 }
@@ -136,6 +143,7 @@ type walker struct {
 	ignorezerovalue bool
 	sets            bool
 	stringer        bool
+	binary          bool
 }
 
 type visitOpts struct {
@@ -201,18 +209,6 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 		// A direct hash calculation
 		w.h.Reset()
 		err := binary.Write(w.h, binary.LittleEndian, v.Interface())
-		return w.h.Sum64(), err
-	}
-
-	switch v.Type() {
-	case timeType:
-		w.h.Reset()
-		b, err := v.Interface().(time.Time).MarshalBinary()
-		if err != nil {
-			return 0, err
-		}
-
-		err = binary.Write(w.h, binary.LittleEndian, b)
 		return w.h.Sum64(), err
 	}
 
@@ -286,6 +282,11 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 			return impl.Hash()
 		}
 
+		// Use BinaryMarshaler whenever possible
+		if bm, ok := parent.(encoding.BinaryMarshaler); w.binary && ok {
+			return hashBinary(w.h, bm)
+		}
+
 		// If we can address this value, check if the pointer value
 		// implements our interfaces and use that if so.
 		if v.CanAddr() {
@@ -297,6 +298,11 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 
 			if impl, ok := parentptr.(Hashable); ok {
 				return impl.Hash()
+			}
+
+			// Use BinaryMarshaler whenever possible
+			if bm, ok := parentptr.(encoding.BinaryMarshaler); w.binary && ok {
+				return hashBinary(w.h, bm)
 			}
 		}
 
@@ -441,6 +447,18 @@ func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
 	}
 
 	return h.Sum64()
+}
+
+// hashBinary will use the BinaryMarshaler implementation of types implementing that interface to generate a hash. Like time.Time or url.URL
+func hashBinary(h hash.Hash64, bm encoding.BinaryMarshaler) (uint64, error) {
+	b, err := bm.MarshalBinary()
+	if err != nil {
+		return 0, err
+	}
+
+	h.Reset()
+	err = binary.Write(h, binary.LittleEndian, b)
+	return h.Sum64(), err
 }
 
 func hashUpdateUnordered(a, b uint64) uint64 {

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -337,9 +337,7 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				}
 
 				// if string is set, use the string value, if not using stringers
-				//fmt.Println(canBinary(innerV.Interface()))
 				if tag == "string" || (w.stringer && !w.binary && !canBinary(innerV.Interface())) {
-					//fmt.Printf("string!!")
 					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
 						innerV = reflect.ValueOf(impl.String())
 					} else if tag == "string" {
@@ -468,7 +466,6 @@ func hashBinary(h hash.Hash64, bm encoding.BinaryMarshaler) (uint64, error) {
 
 	h.Reset()
 	err = binary.Write(h, binary.LittleEndian, b)
-	fmt.Printf("bin hashed! %+v %d\n", bm, h.Sum64())
 	return h.Sum64(), err
 }
 

--- a/hashstructure.go
+++ b/hashstructure.go
@@ -272,7 +272,6 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 				if w.stringer {
 					if impl, ok := innerV.Interface().(fmt.Stringer); ok {
 						innerV = reflect.ValueOf(impl.String())
-						continue
 					}
 				}
 

--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -192,7 +192,7 @@ func TestHash_equal(t *testing.T) {
 				time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
 					now.Minute(), now.Second(), now.Nanosecond(), now.Location()), // does not contain monotonic clock
 			},
-			false,
+			false, // False, since we need to test that setting the `string` tag disables binary hashing
 		},
 	}
 
@@ -222,13 +222,13 @@ func TestHash_equal(t *testing.T) {
 		})
 		t.Run(fmt.Sprintf("%d_UseStringer", i), func(t *testing.T) {
 			t.Logf("Hashing: %#v", tc.One)
-			one, err := Hash(tc.One, testFormat, &HashOptions{UseBinary: true})
+			one, err := Hash(tc.One, testFormat, &HashOptions{UseStringer: true, UseBinary: true})
 			t.Logf("Result: %d", one)
 			if err != nil {
 				t.Fatalf("Failed to hash %#v: %s", tc.One, err)
 			}
 			t.Logf("Hashing: %#v", tc.Two)
-			two, err := Hash(tc.Two, testFormat, &HashOptions{UseBinary: true})
+			two, err := Hash(tc.Two, testFormat, &HashOptions{UseStringer: true, UseBinary: true})
 			t.Logf("Result: %d", two)
 			if err != nil {
 				t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
@@ -721,6 +721,98 @@ func TestHash_hashable(t *testing.T) {
 			// Compare
 			if (one == two) != tc.Match {
 				t.Fatalf("bad, expected: %#v\n\n%#v\n\n%#v", tc.Match, tc.One, tc.Two)
+			}
+		})
+	}
+}
+func TestHash_binary(t *testing.T) {
+	now := time.Now()
+	type TestTime struct {
+		Name string
+		T    time.Time
+	}
+	type TestTimeTag struct {
+		Name string
+		T    time.Time `hash:"string"`
+	}
+	cases := []struct {
+		One, Two interface{}
+		Match    bool
+		S        bool // set to true if test should use "UseStringer"
+		B        bool // set to true if test should use "UseBinary"
+		Err      string
+	}{
+		{
+			TestTime{"One", now},
+			TestTime{"Two", now.Add(time.Second)},
+			false,
+			false,
+			true,
+			"",
+		},
+		{
+			TestTime{Name: "monotonic clock binary", T: now},
+			TestTime{Name: "monotonic clock binary", T: time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
+				now.Minute(), now.Second(), now.Nanosecond(), now.Location()),
+			},
+			true,
+			false,
+			true,
+			"",
+		},
+		{
+			TestTimeTag{Name: "monotonic clock binary string tag", T: now},
+			TestTimeTag{Name: "monotonic clock binary string tag", T: time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
+				now.Minute(), now.Second(), now.Nanosecond(), now.Location()),
+			},
+			false, // string tag overrides the binary option
+			false,
+			true,
+			"",
+		},
+		{
+			TestTime{Name: "monotonic clock binary stringer option", T: now},
+			TestTime{Name: "monotonic clock binary stringer option", T: time.Date(now.Year(), now.Month(), now.Day(), now.Hour(),
+				now.Minute(), now.Second(), now.Nanosecond(), now.Location()),
+			},
+			true, // UseStringer option should NOT override the binary option
+			false,
+			true,
+			"",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			one, err := Hash(tc.One, testFormat, &HashOptions{UseBinary: tc.B, UseStringer: tc.S})
+			if tc.Err != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+
+				if !strings.Contains(err.Error(), tc.Err) {
+					t.Fatalf("expected error to contain %q, got: %s", tc.Err, err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("Failed to hash %#v: %s", tc.One, err)
+			}
+
+			two, err := Hash(tc.Two, testFormat, &HashOptions{UseBinary: tc.B, UseStringer: tc.S})
+			if err != nil {
+				t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
+			}
+
+			// Zero is always wrong
+			if one == 0 {
+				t.Fatalf("zero hash: %#v", tc.One)
+			}
+
+			// Compare
+			if (one == two) != tc.Match {
+				t.Fatalf("bad, expected: %t\n%+v\n%d\n%+v\n%d", tc.Match, tc.One, one, tc.Two, two)
 			}
 		})
 	}


### PR DESCRIPTION
This introduces an option, `UseBinary`, which will use the `encoding.MarshalBinary` interface of any type implementing it. This fixes hashes of time value for one thing, and expands on the time.Time specific changes from #21 .

Since this could be a breaking change, it is hidden behind a new "UseBinary" option. For types that implement both `fmt.Stringer` and `encoding.MarshalBinary` (like `time.Time`), and when both UseBinary and UseStringer are set, the Binary option is preferred, unless the `string` tag is specifically set on the struct member.