### PR TITLE
Fallback hash methods if a struct is 100% ignored

### DIFF
--- a/hashstructure_test.go
+++ b/hashstructure_test.go
@@ -738,7 +738,7 @@ func (u Unexported) String() string {
 	return fmt.Sprintf("%d", u.n)
 }
 
-func TestHash_unexported_stringable(t *testing.T) {
+func TestHash_StringIgnoredStructs(t *testing.T) {
 	cases := []struct {
 		One, Two interface{}
 		Match    bool
@@ -784,7 +784,7 @@ func TestHash_unexported_stringable(t *testing.T) {
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			one, err := Hash(tc.One, testFormat, &HashOptions{})
+			one, err := Hash(tc.One, testFormat, &HashOptions{StringIgnoredStructs: true})
 			if tc.Err != "" {
 				if err == nil {
 					t.Fatal("expected error")
@@ -800,7 +800,7 @@ func TestHash_unexported_stringable(t *testing.T) {
 				t.Fatalf("Failed to hash %#v: %s", tc.One, err)
 			}
 
-			two, err := Hash(tc.Two, testFormat, nil)
+			two, err := Hash(tc.Two, testFormat, &HashOptions{StringIgnoredStructs: true})
 			if err != nil {
 				t.Fatalf("Failed to hash %#v: %s", tc.Two, err)
 			}


### PR DESCRIPTION
**motivation**
hashstructure has a slightly sharp edge in that if a struct contains only unexported fields, that it will hash to the same identity. This is undesirable because many structs contain _only_ unexported fields, but semantically do not represent the same value to the user.

`UseStringer` is not preferable for two reasons:
 - we don't want to cast things to string if we can help it, because it could be unnecessary/expensive
 - UseStringer will not work correctly in some cases (e.g. if you have a map[string]interface{}, the values will not be stringed before hashing).

**explanation**
this change keeps track of which fields are involved in computing a hash. If no fields from a struct are involved, then hashstructure will attempt to `.MashalBinary()` or `.String()` and hash that instead.

I put this behind a flag to maintain compatibility, but some default behaviour like this might be a good idea for a 3.x release.

**note**
I apologize for the formatting updates--my IDE styled it automatically.

If this request is accepted, I will revert the styling changes.

